### PR TITLE
Revise convergence page and plots

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,10 +22,10 @@ makedocs(
     warnonly = Documenter.except(:autodocs_block, :cross_references, :docs_block, :doctest, :eval_block, :example_block, :footnote, :linkcheck_remotes, :linkcheck, :meta_block, :parse_error, :setup_block),
     pages = [
         "Home" => "index.md",
+        "Tutorial" => "tutorial.md",
         "Theory" => "theory.md",
         "Implementation" => "implementation.md",
         "Convergence" => "convergence.md",
-        "Tutorial" => "tutorial.md",
         "Examples" => [
             "Harmonic Oscillator" => "examples/harmonic_oscillator.md",
             "Pendulum" => "examples/pendulum.md",

--- a/docs/src/convergence.md
+++ b/docs/src/convergence.md
@@ -1,9 +1,11 @@
 # Convergence
 
-The previous guides move a curve or surface along the flow of a dynamical system. Here we
-instead study the *accuracy* of the invariant computation itself: how well are the first and
-second Poincaré invariants approximated as we increase the number of sample points, and how
-does this hold up when the curve or surface is severely deformed?
+Having seen how the invariants are represented and computed (see [Theory](@ref) and
+[Implementation](@ref)), we now study the *accuracy* of that computation: how well are the
+first and second Poincaré invariants approximated as we increase the number of sample points,
+and how does this hold up when the curve or surface is severely deformed? Answering this
+tells us how many points to budget for a given accuracy when the package is applied to real
+dynamics, as in the tutorial and examples.
 
 To that end we apply an analytic area-preserving ("symplectic") map repeatedly to an initial
 curve and surface. Because the map preserves area, it preserves both Poincaré invariants
@@ -27,77 +29,150 @@ wavy(x, y, n) = n == 0 ? (x, y) : wavy(wavy(x, y)..., n - 1)
 loopmap(θ, n)    = wavy(cospi(2θ), -sinpi(2θ), n)
 surfmap(x, y, n) = wavy(2x - 1, 2y - 1, n)
 
-# error clamped to machine epsilon so it can be shown on a logarithmic axis
-calcerr(I, I0) = max(abs(I - I0), eps())
+# relative error clamped to machine epsilon so it can be shown on a logarithmic axis
+relerr(I, I0) = max(abs(I - I0) / abs(I0), eps())
+
+# step label used throughout, e.g. "1 Step", "3 Steps"
+steplabel(n) = "$n Step" * (n == 1 ? "" : "s")
 nothing # hide
 ```
 
-## Deformation
+## Deformation of the Loop
 
 Applying the map repeatedly winds the initial unit circle into an increasingly intricate
 curve:
 
 ```@example convergence
 θs = range(0, 1; length = 2000)
+positions = [(1, 1), (1, 2), (2, 1), (2, 2)]
+curves = [[loopmap(θ, n) for θ in θs] for n in 0:3]
+
+# shared square limits so all four panels have the same size and a 1:1 aspect ratio
+allpts = reduce(vcat, curves)
+xr, yr = extrema(first.(allpts)), extrema(last.(allpts))
+cx, cy = (xr[1] + xr[2]) / 2, (yr[1] + yr[2]) / 2
+r = max(xr[2] - xr[1], yr[2] - yr[1]) / 2
+lims = (cx - r, cx + r, cy - r, cy + r)
 
 fig = Figure()
-ax = Axis(fig[1, 1]; xlabel = "q", ylabel = "p", aspect = DataAspect(), title = "deformed loop")
-for n in 0:3
-    pts = [loopmap(θ, n) for θ in θs]
-    lines!(ax, first.(pts), last.(pts); label = "$n applications")
+for (n, pos, pts) in zip(0:3, positions, curves)
+    ax = Axis(fig[pos...]; xlabel = "q", ylabel = "p",
+        width = 450, height = 450, limits = lims, title = steplabel(n))
+    lines!(ax, first.(pts), last.(pts))
 end
-axislegend(ax; position = :lt)
+Label(fig[0, :], "Deformation of the Loop")
+resize_to_layout!(fig)
 fig
 ```
 
-## First invariant
+## First Invariant
 
 We compute the first invariant $I_1 = \oint_\gamma p \, dq = \pi$ on the deformed loop for a
-range of point numbers. The `FirstFourierPlan` converges spectrally, reaching machine
-precision even for the strongly deformed curves once enough points are used.
+range of point numbers. Because the loop stays smooth and periodic under `wavy`, the
+`FirstFourierPlan` converges spectrally: with enough points the relative error falls to
+essentially machine precision, even for the more strongly deformed curves. As the number of
+deformation steps grows, the curve winds tighter and more points are needed before this
+spectral convergence sets in.
 
 ```@example convergence
-Ns = [50, 100, 150, 200, 300, 500, 1000]
+Ns = [50, 100, 200, 500, 1000, 2000, 5000, 10000]
 
 fig = Figure()
 ax = Axis(fig[1, 1]; xscale = log10, yscale = log10,
-    xlabel = "number of points", ylabel = "absolute error in I₁", title = "First invariant")
+    xlabel = "number of points", ylabel = "Relative Error in I₁",
+    title = "First Poincaré Invariant")
 for n in 1:3
     errs = map(Ns) do N
         pinv = CanonicalFirstPI{Float64, 2}(N)
-        calcerr(compute!(pinv, getpoints(θ -> loopmap(θ, n), pinv)), π)
+        relerr(compute!(pinv, getpoints(θ -> loopmap(θ, n), pinv)), π)
     end
-    scatterlines!(ax, Ns, errs; label = "$n applications")
+    scatterlines!(ax, Ns, errs; label = steplabel(n))
 end
 axislegend(ax; position = :rt)
 fig
 ```
 
-## Second invariant
+## Deformation of the Surface
 
-The second invariant $I_2 = \int_S dq \wedge dp = 4$ is computed with the Chebyshev/Padua
-representation of the surface. The two-dimensional surface is harder to resolve than the
-one-dimensional curve, so more points are needed, but the error still decreases rapidly with
-the number of points.
+The same map, applied to the initial 2×2 square, folds it into an increasingly convoluted
+surface. To visualise this we track a family of grid lines running in the two parameter
+directions and follow their images under the deformation:
 
 ```@example convergence
-Ns = [100, 500, 1000, 2000, 5000, 10000]
+ts = range(0, 1; length = 200)
+grid = range(0, 1; length = 11)
+positions = [(1, 1), (1, 2), (2, 1), (2, 2)]
+
+# constant-x (vertical) and constant-y (horizontal) grid lines, deformed n times
+gridlines(n) = (
+    [[surfmap(x, t, n) for t in ts] for x in grid],
+    [[surfmap(t, y, n) for t in ts] for y in grid],
+)
+panels = [gridlines(n) for n in 0:3]
+
+# shared square limits so all four panels have the same size and a 1:1 aspect ratio
+allpts = reduce(vcat, [reduce(vcat, [vert; horz]) for (vert, horz) in panels])
+xr, yr = extrema(first.(allpts)), extrema(last.(allpts))
+cx, cy = (xr[1] + xr[2]) / 2, (yr[1] + yr[2]) / 2
+r = max(xr[2] - xr[1], yr[2] - yr[1]) / 2
+lims = (cx - r, cx + r, cy - r, cy + r)
+
+fig = Figure()
+for (n, pos, (vert, horz)) in zip(0:3, positions, panels)
+    ax = Axis(fig[pos...]; xlabel = "q", ylabel = "p",
+        width = 450, height = 450, limits = lims, title = steplabel(n))
+    for line in vert
+        lines!(ax, first.(line), last.(line); color = :steelblue)
+    end
+    for line in horz
+        lines!(ax, first.(line), last.(line); color = :firebrick)
+    end
+end
+Label(fig[0, :], "Deformation of the Surface")
+resize_to_layout!(fig)
+fig
+```
+
+## Second Invariant
+
+The second invariant $I_2 = \int_S dq \wedge dp = 4$ is computed with the Chebyshev/Padua
+representation of the surface (`SecondChebyshevPlan`). The two-dimensional surface is
+markedly harder to resolve than the one-dimensional loop: even a single application of the
+map needs far more sample points than the corresponding loop computation, and each additional
+deformation step pushes the point count needed for convergence up sharply, mirroring the way
+the grid-line plots above fold the surface over itself ever more tightly. Once deformed, the
+error reaches machine precision within a few thousand points; twice deformed, only near the
+largest counts tested; and for the thrice-deformed surface the error lingers at order unity
+across most of the range, beginning to fall appreciably only at the very largest point count.
+This underlines how much more expensive an accurate bivariate polynomial representation
+becomes as the surface is folded.
+
+```@example convergence
+Ns = [100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000]
 
 fig = Figure()
 ax = Axis(fig[1, 1]; xscale = log10, yscale = log10,
-    xlabel = "number of points", ylabel = "absolute error in I₂", title = "Second invariant")
+    xlabel = "number of points", ylabel = "Relative Error in I₂",
+    title = "Second Poincaré Invariant")
 for n in 1:3
     errs = map(Ns) do N
         pinv = CanonicalSecondPI{Float64, 2}(N)
-        calcerr(compute!(pinv, getpoints((x, y) -> surfmap(x, y, n), pinv)), 4.0)
+        relerr(compute!(pinv, getpoints((x, y) -> surfmap(x, y, n), pinv)), 4.0)
     end
-    scatterlines!(ax, Ns, errs; label = "$n applications")
+    scatterlines!(ax, Ns, errs; label = steplabel(n))
 end
 axislegend(ax; position = :rt)
 fig
 ```
 
-Even under severe deformation the spectral representations used by `FirstFourierPlan` and
-`SecondChebyshevPlan` (see [Using Different Integral Implementations](@ref)) recover the
-invariants to high accuracy, which is what makes them suitable for tracking invariants along
-the flow of a dynamical system.
+## Conclusions
+
+Both `FirstFourierPlan` and `SecondChebyshevPlan` (see [Using Different Integral
+Implementations](@ref)) are spectral methods, so with enough points they recover the
+invariants to high accuracy on smooth, moderately deformed loops and surfaces alike. The
+loop's one-dimensional Fourier representation keeps up with even severe deformation once
+enough points are used; the surface's two-dimensional Chebyshev/Padua representation is
+inherently more expensive and, under the most severe deformation, can require far more points
+than are practical to reach the same accuracy. This is exactly the trade-off to keep in mind
+when tracking invariants along the flow of a dynamical system: the finer the structure that
+develops, the more samples the computation needs to remain trustworthy.


### PR DESCRIPTION
## Summary

Revises the **Convergence** documentation page (`docs/src/convergence.md`) so it matches the rest of the docs and reflects the restructured navigation, and reorders the nav in `docs/make.jl` (Tutorial now directly after Home).

### Text
- Rewrites the intro to follow the Theory/Implementation pages and stay neutral to the tutorial/examples ordering.
- Updates the findings prose to match the regenerated plots — notably that the twice-deformed surface only reaches machine precision near the largest point counts, and the thrice-deformed surface begins to converge only at the very largest count.

### Plots (house style)
- Relative invariant errors and Title-Case titles, consistent with the Makie extension; clearer y-axis labels (`Relative Error in I₁` / `Relative Error in I₂`).
- Curve labels `1 Step`, `2 Steps`, … instead of `N applications`.
- Loop deformation split into four equally sized, square (1:1) subplots.
- New analogous surface-deformation plot, drawn as warped grid lines.
- Extended point sweeps: first invariant up to `10^4`, second invariant up to `10^5`.

## Verification
- `julia --project=docs -e 'include("docs/make.jl")'` builds cleanly (exit 0); the `@example convergence` blocks all evaluate without error.
- Regenerated figures inspected: square undistorted deformation panels (circle stays a circle, square stays a square), relative-error axes, Title-Case titles, and `N Step(s)` legends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)