### PR TITLE
Singular problems + in-place differential-form interface

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -8,12 +8,11 @@ SUITE["SecondPoincareInvariants"] = BenchmarkGroup()
 
 SUITE["SecondPoincareInvariants"]["canonical"] = BenchmarkGroup()
 for N in [100 * 100, 1000 * 1000], D in [2, 12, 100]
-    name = "SecondPoincareInvariant{Float64}(ω, $D, $N)"
+    name = "CanonicalSecondPI{Float64, $D}($N)"
 
     SUITE["SecondPoincareInvariants"]["canonical"][name] =
         @benchmarkable compute!(pinv, phasepoints, 0, nothing) setup=begin
-            ω(z, t, p) = canonical_two_form($D)
-            pinv = SecondPoincareInvariant{Float64}(ω, $D, $N)
+            pinv = CanonicalSecondPI{Float64, $D}($N)
             phasepoints = getpoints(pinv) do x, y
                 rand($D)
             end

--- a/docs/src/examples/lotka_volterra.md
+++ b/docs/src/examples/lotka_volterra.md
@@ -30,23 +30,23 @@ using StaticArrays
 using CairoMakie
 
 prob = lodeproblem([2.0, 1.0]; timespan = (0.0, 1.0), timestep = 0.02)
+par  = parameters(prob)
 nothing # hide
 ```
 
 ## The invariant forms
 
-The one-form $\vartheta$ and the two-form $\omega = d\vartheta$ are exported by the problem
-module (`ϑ` and the in-place `ω`); we only adapt them to the `form(z, t, p)` interface.
-Neither depends on the physical parameters, so `p` is ignored.
+The noncanonical symplectic one-form $\vartheta$ and two-form $\omega = d\vartheta$ belong to
+the `LODEProblem` itself. We take them straight from the problem's function tuple with
+`functions(prob)`, so the invariant forms are guaranteed to be exactly the (in-place,
+parameter-carrying) functions the problem was integrated with; we only adapt them to the
+`form(z, t, p)` interface, forwarding the parameters `par` through the `p` slot.
 
 ```@example lotka
-oneform(z, t, p) = SVector{2}(ϑ(t, z))
+fs = functions(prob)
 
-function twoform(z, t, p)
-    Ω = zeros(eltype(z), 2, 2)
-    ω(Ω, t, z)
-    SMatrix{2, 2}(Ω)
-end
+oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
+twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 nothing # hide
 ```
 
@@ -74,7 +74,7 @@ plot_loop(sol1; xlabel = "q₁", ylabel = "q₂")
 ```
 
 ```@example lotka
-plot_invariant(pi1, sol1; title = "First Poincaré invariant")
+plot_invariant(pi1, sol1; p = par, title = "First Poincaré invariant")
 ```
 
 ## Second invariant
@@ -99,7 +99,7 @@ plot_surface(grid, solg; xlabel = "q₁", ylabel = "q₂")
 ```
 
 ```@example lotka
-plot_invariant(pi2, sol2; title = "Second Poincaré invariant")
+plot_invariant(pi2, sol2; p = par, title = "Second Poincaré invariant")
 ```
 
 The relative errors stay at the level of machine precision: with the correct form of the

--- a/docs/src/examples/lotka_volterra.md
+++ b/docs/src/examples/lotka_volterra.md
@@ -37,16 +37,15 @@ nothing # hide
 ## The invariant forms
 
 The noncanonical symplectic one-form $\vartheta$ and two-form $\omega = d\vartheta$ belong to
-the `LODEProblem` itself. We take them straight from the problem's function tuple with
-`functions(prob)`, so the invariant forms are guaranteed to be exactly the (in-place,
-parameter-carrying) functions the problem was integrated with; we only adapt them to the
-`form(z, t, p)` interface, forwarding the parameters `par` through the `p` slot.
+the `LODEProblem` itself. `PoincareInvariants` expects a differential form as an **in-place**
+function `form(out, t, z, p)` — writing its value at the phase space point `z` into the
+preallocated `out` — and this is exactly the convention `GeometricProblems` uses for its
+one- and two-forms (`ϑ(Θ, t, q, params)`, `ω(Ω, t, q, params)`). We can therefore take them
+straight from the problem's function tuple with `functions(prob)` and pass `fs.ϑ` / `fs.ω`
+**directly** to `FirstPI` / `SecondPI` below, with no wrapper:
 
 ```@example lotka
 fs = functions(prob)
-
-oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
-twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 nothing # hide
 ```
 
@@ -62,7 +61,7 @@ We advect a circle of radius $\rho = 0.2$ around the initial point $(2, 1)$.
 q₀ = SVector(2.0, 1.0)
 ρ  = 0.2
 
-pi1  = FirstPI{Float64, 2}(oneform, 500)
+pi1  = FirstPI{Float64, 2}(fs.ϑ, 500)
 sol1 = integrate(PIEnsembleProblem(prob, pi1, ϕ -> q₀ .+ ρ .* (cospi(2ϕ), sinpi(2ϕ))), DVRK(Gauss(2)))
 nothing # hide
 ```
@@ -86,13 +85,13 @@ I_{2} = \int_{S} \omega_{ij}(q) \, dq^i \, dq^j
 We advect a square around $(2, 1)$, staying within the positive quadrant.
 
 ```@example lotka
-pi2  = SecondPI{Float64, 2}(twoform, 2_000)
+pi2  = SecondPI{Float64, 2}(fs.ω, 2_000)
 sol2 = integrate(PIEnsembleProblem(prob, pi2, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1)), DVRK(Gauss(2)))
 nothing # hide
 ```
 
 ```@example lotka
-grid = SecondPI{Float64, 2}(twoform, (15, 15), SecondFinDiffPlan)
+grid = SecondPI{Float64, 2}(fs.ω, (15, 15), SecondFinDiffPlan)
 solg = integrate(PIEnsembleProblem(prob, grid, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1)), DVRK(Gauss(2)))
 
 plot_surface(grid, solg; xlabel = "q₁", ylabel = "q₂")

--- a/docs/src/examples/massless_charged_particle.md
+++ b/docs/src/examples/massless_charged_particle.md
@@ -9,52 +9,60 @@ L(x, \dot{x}) = A(x) \cdot \dot{x} - \phi(x) ,
 ```
 
 with magnetic vector potential $A$, electrostatic potential $\phi$ and magnetic field
-$B(x) = \nabla \times A(x)$. The Hamiltonian form of the equations of motion,
+$B(x) = \nabla \times A(x)$. We use the `MasslessChargedParticleSingular` variant from
+[GeometricProblems.jl](https://github.com/JuliaGNI/GeometricProblems.jl), which describes the
+same physical system in a "singular" magnetic gauge whose vector potential has only one
+nonzero component,
+
+```math
+A(x) = - A_0 \, x_2 \, \big( 1 + 2 x_1^2 + \tfrac{2}{3} x_2^2 \big) \begin{pmatrix} 1 \\ 0 \end{pmatrix} ,
+\qquad
+\phi(x) = E_0 \, \big( \cos x_1 + \sin x_2 \big) ,
+\qquad
+B(x) = A_0 \, (1 + 2 x_1^2 + 2 x_2^2) .
+```
+
+The magnetic field $B$, the electric field and hence the Hamiltonian form of the equations of
+motion,
 
 ```math
 \dot{x} = \frac{1}{B(x)} \begin{pmatrix} 0 & -1 \\ +1 & 0 \end{pmatrix} \nabla \phi(x) ,
 ```
 
-carries a state-dependent (noncanonical) symplectic structure. We use the problem and its
-exported forms from
-[GeometricProblems.jl](https://github.com/JuliaGNI/GeometricProblems.jl), integrating the
-degenerate `IODEProblem` with a **Degenerate Variational Runge-Kutta** method, `DVRK`, which
-preserves the noncanonical structure. The plotting functions `plot_loop`, `plot_surface` and
-`plot_invariant` come from the package's Makie extension, activated by loading `CairoMakie`.
+are identical to the standard gauge — only the vector potential differs by a gauge
+transformation. This singular one-form $\vartheta = A(x)$ is exactly the form of the
+symplectic potential that the `DVRK` (**Degenerate Variational Runge-Kutta**) integrator
+expects, so integrating the degenerate `LODEProblem` with `DVRK` preserves the noncanonical
+symplectic structure $\omega = d\vartheta$ — and with it the Poincaré invariants — to machine
+accuracy. The plotting functions `plot_loop`, `plot_surface` and `plot_invariant` come from
+the package's Makie extension, activated by loading `CairoMakie`.
 
 ```@example particle
 using PoincareInvariants
 using GeometricIntegrators
-import GeometricProblems.MasslessChargedParticle as MCP
+import GeometricProblems.MasslessChargedParticleSingular as MCP
 using StaticArrays
 using CairoMakie
 
-par  = MCP.default_parameters()
-prob = MCP.iodeproblem([1.0, 1.0]; timespan = (0.0, 5.0), timestep = 0.1)
+prob = MCP.lodeproblem([1.0, 1.0]; timespan = (0.0, 5.0), timestep = 0.1)
+par  = parameters(prob)
 nothing # hide
 ```
 
 ## The invariant forms
 
 The first invariant uses the one-form $\vartheta = A(x)$ (the magnetic vector potential), and
-the second uses the two-form $\omega = d\vartheta$, which for this system is
-
-```math
-\omega = \begin{pmatrix} 0 & B(x) \\ -B(x) & 0 \end{pmatrix} .
-```
-
-Both are provided directly by the problem module (`ϑ` and `B`), so we only reshape them into
-the `form(z, t, p)` interface expected by `PoincareInvariants`. The parameter slot `p`
-carries the physical parameters `par`.
+the second uses the two-form $\omega = d\vartheta$ (the magnetic field). As in the
+Lotka-Volterra example, both belong to the `LODEProblem` itself, so we take them straight from
+the problem's function tuple with `functions(prob)` — guaranteeing the invariant forms are
+exactly the (in-place, parameter-carrying) functions the problem was integrated with — and
+only adapt them to the `form(z, t, p)` interface, forwarding the parameters `par` through `p`.
 
 ```@example particle
-oneform(z, t, p) = SVector{2}(MCP.ϑ(t, z, p))
+fs = functions(prob)
 
-function twoform(z, t, p)
-    b = MCP.B(z, p)
-    @SMatrix [0.0  b;
-              -b   0.0]
-end
+oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
+twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 nothing # hide
 ```
 
@@ -112,6 +120,6 @@ plot_invariant(pi2, sol2; p = par, title = "Second Poincaré invariant")
 ```
 
 The `DVRK(Gauss(2))` method is a fourth-order variational integrator for noncanonical
-symplectic systems, so both invariants are conserved with high accuracy as the curve and
-surface are advected by the flow. A standard, structure-agnostic integrator would let them
-drift.
+symplectic systems. Because the singular gauge provides exactly the symplectic potential it
+expects, both invariants are conserved to machine precision as the curve and surface are
+advected by the flow. A standard, structure-agnostic integrator would let them drift.

--- a/docs/src/examples/massless_charged_particle.md
+++ b/docs/src/examples/massless_charged_particle.md
@@ -53,16 +53,14 @@ nothing # hide
 
 The first invariant uses the one-form $\vartheta = A(x)$ (the magnetic vector potential), and
 the second uses the two-form $\omega = d\vartheta$ (the magnetic field). As in the
-Lotka-Volterra example, both belong to the `LODEProblem` itself, so we take them straight from
-the problem's function tuple with `functions(prob)` — guaranteeing the invariant forms are
-exactly the (in-place, parameter-carrying) functions the problem was integrated with — and
-only adapt them to the `form(z, t, p)` interface, forwarding the parameters `par` through `p`.
+Lotka-Volterra example, both belong to the `LODEProblem` itself. `PoincareInvariants` expects a
+differential form as an **in-place** function `form(out, t, z, p)`, which is exactly the
+convention `GeometricProblems` uses (`ϑ(Θ, t, q, params)`, `ω(Ω, t, q, params)`), so we take
+them from the problem's function tuple with `functions(prob)` and pass `fs.ϑ` / `fs.ω`
+**directly** to `FirstPI` / `SecondPI`, with no wrapper:
 
 ```@example particle
 fs = functions(prob)
-
-oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
-twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 nothing # hide
 ```
 
@@ -79,7 +77,7 @@ the parameters `par` to [`compute!`](@ref) (via `plot_invariant`) so the form ca
 q₀ = SVector(1.0, 1.0)
 ρ  = 0.2
 
-pi1  = FirstPI{Float64, 2}(oneform, 500)
+pi1  = FirstPI{Float64, 2}(fs.ϑ, 500)
 sol1 = integrate(PIEnsembleProblem(prob, pi1, ϕ -> q₀ .+ ρ .* (cospi(2ϕ), sinpi(2ϕ))), DVRK(Gauss(2)))
 nothing # hide
 ```
@@ -103,13 +101,13 @@ I_{2} = \int_{S} \omega = \int_{S} B(x) \, dx_1 \, dx_2
 is the magnetic flux through the surface $S$. We advect a small square around $(1, 1)$.
 
 ```@example particle
-pi2  = SecondPI{Float64, 2}(twoform, 2_000)
+pi2  = SecondPI{Float64, 2}(fs.ω, 2_000)
 sol2 = integrate(PIEnsembleProblem(prob, pi2, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1)), DVRK(Gauss(2)))
 nothing # hide
 ```
 
 ```@example particle
-grid = SecondPI{Float64, 2}(twoform, (15, 15), SecondFinDiffPlan)
+grid = SecondPI{Float64, 2}(fs.ω, (15, 15), SecondFinDiffPlan)
 solg = integrate(PIEnsembleProblem(prob, grid, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1)), DVRK(Gauss(2)))
 
 plot_surface(grid, solg; xlabel = "x₁", ylabel = "x₂")

--- a/docs/src/implementation.md
+++ b/docs/src/implementation.md
@@ -54,6 +54,8 @@ Both plans have finite-difference counterparts (`FirstFinDiffPlan`, `SecondFinDi
 
 ## Using Different Integral Implementations
 
+In every implementation the differential form is supplied as an **in-place** function following the convention `form(out, t, z, p)`: it writes its value at the phase space point `z` (a single point) into the preallocated output `out` — a length-`D` vector for a one-form `θ`, a `D×D` matrix for a two-form `ω`. This argument order matches the one- and two-forms exported by `GeometricEquations`/`GeometricProblems` (`ϑ(Θ, t, q, params)`, `ω(Ω, t, q, params)`), so a problem's own forms can be passed straight to `FirstPI`/`SecondPI`. Internally each plan fills a single preallocated [`StaticArrays`](https://github.com/JuliaArrays/StaticArrays.jl) buffer (an `MVector`/`MMatrix`) and reuses it across all sample points, so evaluating the form allocates nothing. A constant `ω::AbstractMatrix` (such as a `CanonicalSymplecticMatrix`) is used directly and is not called.
+
 There are a number of different implementations to choose from to calculate the invariants. For the first invariant, the choices are
 
 ```Julia

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -17,7 +17,7 @@ compute!
 FirstPoincareInvariant
 FirstPoincareInvariant{T, D}(θ::θT, N::Integer, plan::P) where {T, D, θT, P}
 FirstPoincareInvariant{T, D}(θ::θT, N::Integer, P::Type=DEFAULT_FIRST_PLAN) where {T, D, θT}
-FirstPoincareInvariant{T, D, typeof(canonical_one_form)}(N::Integer, P=DEFAULT_FIRST_PLAN) where {T, D}
+FirstPoincareInvariant{T, D, typeof(canonical_one_form!)}(N::Integer, P=DEFAULT_FIRST_PLAN) where {T, D}
 SecondPoincareInvariant
 SecondPoincareInvariant{T, D}(ω::ωT, N, plan::P) where {T, D, ωT, P}
 SecondPoincareInvariant{T, D}(ω, N, P::Type=DEFAULT_SECOND_PLAN) where {T, D}
@@ -46,6 +46,7 @@ PIEnsembleProblem
 
 ```@docs
 CanonicalSymplecticMatrix
+canonical_one_form!
 ```
 
 ## Plotting

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -34,29 +34,125 @@ one initial condition:
 - for an `IODEProblem`/`LODEProblem` the position is taken from the point and the momentum is
   initialised from the equation's one-form as `p₀ = ϑ(t₀, q₀)`.
 
+The parameterisation `init` is itself a function that **returns** the sampled point (this is
+separate from the differential form discussed below):
+
+- for the **first** invariant the loop is parameterised by one variable, `ϕ -> (…)`, and must
+  return `D` values (one per phase space coordinate);
+- for the **second** invariant the surface is parameterised by two variables, `(x, y) -> (…)`,
+  again returning `D` values.
+
+## Differential forms
+
+The invariant is the integral of a differential form over the advected curve or surface. How
+you supply that form depends on whether the system is canonical or noncanonical.
+
+- **Canonical** Hamiltonian systems (`HODEProblem`/`PODEProblem` in coordinates `(q, p)`) use
+  the *canonical* symplectic form. Use `CanonicalFirstPI` / `CanonicalSecondPI`,
+  which supply that form internally — you pass **no** form argument.
+- **Noncanonical** symplectic systems carry a state-dependent one-form `ϑ` (and two-form
+  `ω = dϑ`). Use `FirstPI` / `SecondPI` and pass the form explicitly.
+
+A user-supplied form is an **in-place** function following the convention
+
+```julia
+form(out, t, z, p)
+```
+
+where `out` is the preallocated output the form fills — a length-`D` vector for a one-form
+`ϑ`, a `D×D` matrix for a two-form `ω` — `z` is one phase space point, `t` the time and `p`
+the parameters. This argument order is exactly the one `GeometricEquations`/`GeometricProblems`
+use for their forms (`ϑ(Θ, t, q, params)`, `ω(Ω, t, q, params)`), so **a problem's own forms
+can be passed directly**, with no wrapper (see the noncanonical example below). Internally the
+form is only ever called with a preallocated buffer that is reused across sample points, so
+evaluating it allocates nothing.
+
 ## Integrating and computing
 
 Because the number of ensemble members equals the number of sampled points, no trajectory
-count needs to be supplied — simply integrate and compute:
+count needs to be supplied — simply integrate and compute. Here is the full workflow for the
+first invariant of a **canonical** system, the harmonic oscillator:
 
-```julia
+```@example tutorial_canonical
 using PoincareInvariants
 using GeometricIntegrators
 using GeometricProblems.HarmonicOscillator
 
 prob = hodeproblem([0.0], [0.0]; timespan = (0.0, 1.0), timestep = 0.1)
 
+# a circle of radius r around the origin encloses the area π r²
+r = 0.5
 pinv = CanonicalFirstPI{Float64, 2}(500)
-ens  = PIEnsembleProblem(prob, pinv, ϕ -> (0.5 * sinpi(2ϕ), 0.5 * cospi(2ϕ)))
+ens  = PIEnsembleProblem(prob, pinv, ϕ -> (r * sinpi(2ϕ), r * cospi(2ϕ)))
 
 sol = integrate(ens, PartitionedGauss(1))
 Is  = compute!(pinv, sol)
+
+Is[1], maximum(abs, Is .- Is[1])   # initial value ≈ π r², and its drift
 ```
 
-[`compute!`](@ref) returns a `Vector` holding one invariant value per saved time step. An
-optional parameter `p` may be passed as `compute!(pinv, sol, p)`; it is handed to the
-differential form together with the time (this is needed for forms that depend on physical
-parameters, such as the noncanonical examples).
+[`compute!`](@ref) returns a `Vector` holding one invariant value per saved time step. A
+symplectic integrator keeps that value essentially constant, so its drift from `Is[1]` (here
+`maximum(abs, Is .- Is[1])`) is the diagnostic of interest — not the individual values.
+
+The second invariant works the same way with `CanonicalSecondPI` and a surface
+parameterisation `(x, y) -> (…)`; see the [Harmonic Oscillator](examples/harmonic_oscillator.md)
+and [Pendulum](examples/pendulum.md) pages.
+
+## A noncanonical example
+
+For a **noncanonical** system we integrate the degenerate `LODEProblem` (or `IODEProblem`) and
+supply the problem's own one-form/two-form. Both are obtained from the problem with
+`functions(prob)` and passed directly — `fs.ϑ` and `fs.ω` already have the in-place
+`form(out, t, z, p)` signature:
+
+```@example tutorial_noncanonical
+using PoincareInvariants
+using GeometricIntegrators
+using GeometricProblems.LotkaVolterra2dSingular
+
+prob = lodeproblem([2.0, 1.0]; timespan = (0.0, 1.0), timestep = 0.02)
+par  = parameters(prob)   # physical parameters carried by the problem
+fs   = functions(prob)    # the problem's own ϑ, ω, …
+
+q₀ = (2.0, 1.0)
+ρ  = 0.2
+
+# first invariant: advect a small loop around q₀ and pass fs.ϑ directly
+pi1  = FirstPI{Float64, 2}(fs.ϑ, 500)
+ens1 = PIEnsembleProblem(prob, pi1, ϕ -> q₀ .+ ρ .* (cospi(2ϕ), sinpi(2ϕ)))
+sol1 = integrate(ens1, DVRK(Gauss(2)))
+Is1  = compute!(pi1, sol1, par)
+
+# second invariant: advect a small square and pass fs.ω directly
+pi2  = SecondPI{Float64, 2}(fs.ω, 2_000)
+ens2 = PIEnsembleProblem(prob, pi2, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1))
+sol2 = integrate(ens2, DVRK(Gauss(2)))
+Is2  = compute!(pi2, sol2, par)
+
+maximum(abs, Is1 .- Is1[1]), maximum(abs, Is2 .- Is2[1])   # both ≈ machine precision
+```
+
+Note that `par` is passed to [`compute!`](@ref) because the forms depend on the physical
+parameters; omitting it for a parameter-dependent form is a common mistake (see below). The
+fuller [Lotka-Volterra](examples/lotka_volterra.md) and
+[Massless Charged Particle](examples/massless_charged_particle.md) pages carry this through to
+plots of the invariant over time.
+
+## Choosing an invariant and a plan
+
+Each invariant can be computed with more than one numerical plan (see
+[Implementation](implementation.md) for the details):
+
+| invariant | default plan | alternative |
+|-----------|--------------|-------------|
+| first (`FirstPI`)  | `FirstFourierPlan` (spectral, periodic loop) | `FirstFinDiffPlan` (finite differences) |
+| second (`SecondPI`)| `SecondChebyshevPlan` (spectral, Padua points) | `SecondFinDiffPlan` (finite differences) |
+
+The plan is the optional last constructor argument, e.g. `FirstPI{Float64, 2}(ϑ, 500, FirstFinDiffPlan)`.
+The default spectral plans converge exponentially for smooth data and are almost always the
+right choice. `SecondFinDiffPlan` additionally accepts a non-square grid as a tuple `(Nx, Ny)`
+instead of a single point count `N`.
 
 ## Choosing an integrator
 
@@ -70,7 +166,22 @@ structure.
   e.g. `DVRK(Gauss(2))`, which preserves the noncanonical symplectic structure. (The plain
   DVI methods preserve a discrete *canonical* structure and are not suitable here.)
 
+## Common pitfalls
+
+- **Forgetting the parameters.** If the differential form depends on physical parameters, call
+  `compute!(pinv, sol, p)` (and `plot_invariant(pinv, sol; p = …)`). Omitting `p` leaves the
+  form without its parameters and gives wrong values. Canonical invariants take no parameters,
+  so `compute!(pinv, sol)` is enough.
+- **Mismatched dimension.** The `D` in `FirstPI{T, D}` / `CanonicalFirstPI{T, D}` is the phase
+  space dimension and must match the problem; the parameterisation must return `D` values per
+  point.
+- **A non-symplectic (or wrong) integrator.** With a structure-agnostic method the invariant
+  drifts even though the code runs without error. Match the integrator to the structure as
+  above; judge conservation by the drift of `compute!`'s output from its initial value.
+- **Reading individual values instead of the drift.** `compute!` returns the invariant at every
+  saved time step. What matters is how little it changes over time, i.e. `Is .- Is[1]`.
+
 The following guides work through a canonical example
-([Harmonic Oscillator](examples/harmonic_oscillator.md), [Pendulum](examples/pendulum.md)) and a noncanonical
-example ([Massless Charged Particle](examples/massless_charged_particle.md),
+([Harmonic Oscillator](examples/harmonic_oscillator.md), [Pendulum](examples/pendulum.md)) and a
+noncanonical example ([Massless Charged Particle](examples/massless_charged_particle.md),
 [Lotka-Volterra](examples/lotka_volterra.md)) in detail.

--- a/src/CanonicalSymplecticForms.jl
+++ b/src/CanonicalSymplecticForms.jl
@@ -3,62 +3,30 @@ module CanonicalSymplecticForms
 import Base
 import LinearAlgebra
 
-export canonical_one_form, CanonicalSymplecticMatrix, canonical_two_form
+export canonical_one_form!, CanonicalSymplecticMatrix
 
 function checkn(T, n::Integer)
     n > 0 || throw(ArgumentError("$T must have positive size"))
     iseven(n) || throw(ArgumentError("$T must have even size"))
 end
 
-struct CanonicalSymplecticVector{T, VT <: AbstractVector{T}} <: AbstractVector{T}
-    p::VT
+"""
+    canonical_one_form!(out, t, z, p)
 
-    function CanonicalSymplecticVector{T, VT}(p) where {T, VT}
-        Base.require_one_based_indexing(p)
-        new{T, VT}(p)
-    end
-end
-
-CanonicalSymplecticVector{T}(p::VT) where {T, VT} = CanonicalSymplecticVector{T, VT}(p)
-CanonicalSymplecticVector(p::VT) where VT = CanonicalSymplecticVector{eltype(p), VT}(p)
-
-Base.size(C::CanonicalSymplecticVector) = (length(C.p) * 2,)
-
-function Base.getindex(C::CanonicalSymplecticVector{T}, i::Int) where T
-    mid = length(C.p)
-    @boundscheck let n = mid * 2
-        if !(1 ≤ i ≤ n)
-            msg = "attempt to access $n-element CanonicalSymplecticVector at index [$i]"
-            throw(BoundsError(msg))
-        end
-    end
-
-    if i ≤ mid
-        return @inbounds C.p[i]
-    else
-        return zero(T)
-    end
-end
-
-function LinearAlgebra.dot(C::CanonicalSymplecticVector, x::AbstractVector)
-    m = length(C.p)
-    axes(x, 1) == 1:2m || throw(DimensionMismatch())
-
-    s = zero(promote_type(eltype(x), eltype(C)))
-    @inbounds for i in 1:m
-        s += C.p[i] * x[i]
-    end
-
-    s
-end
-
-# LinearAlgebra.dot(x::AbstractVector, C::CanonicalSymplecticVector) = LinearAlgebra.dot(C, x)
-
-function canonical_one_form(z, t, p)
+writes the canonical one form ``\\vartheta`` at the phase space point `z` into `out`, following
+the in-place `form(out, t, z, p)` convention. For a phase space point `z = (q, p)` of even
+length `n = 2m`, the canonical one form is ``\\vartheta = (p, 0)``, i.e. `out[1:m] .= z[m+1:n]`
+and `out[m+1:n] .= 0`. The time `t` and parameters `p` are ignored.
+"""
+function canonical_one_form!(out, t, z, p)
     n = length(z)
     iseven(n) || throw(ArgumentError("z must have even length"))
     mid = n ÷ 2
-    CanonicalSymplecticVector(view(z, mid+1:n))
+    @inbounds @views begin
+        out[1:mid] .= z[mid+1:n]
+        out[mid+1:n] .= zero(eltype(out))
+    end
+    return out
 end
 
 """
@@ -128,7 +96,5 @@ function LinearAlgebra.dot(x::AbstractVector, C::CanonicalSymplecticMatrix, y::A
 
     s
 end
-
-canonical_two_form(z, t, p) = CanonicalSymplecticMatrix{eltype(z)}(length(z))
 
 end  # module

--- a/src/FirstFinDiffPlans.jl
+++ b/src/FirstFinDiffPlans.jl
@@ -1,7 +1,7 @@
 module FirstFinDiffPlans
 
 using LinearAlgebra: dot
-using StaticArrays: SVector
+using StaticArrays: MVector
 
 using ..PoincareInvariants: FirstPoincareInvariant, getpointnum, getform
 
@@ -19,23 +19,27 @@ function compute!(
     θ = getform(pinv)
     I = zero(T)
 
-    dzi = Vector{T}(undef, D)
+    dzi = MVector{D, T}(undef)
+    θi = MVector{D, T}(undef)
 
     for i in 2:N-1
         zi = view(zs, i, :)
         dzi .= @views (zs[i+1, :] .- zs[i-1, :]) ./ 2
-        I += dot(θ(zi, t, p), dzi)
+        θ(θi, t, zi, p)
+        I += dot(θi, dzi)
     end
 
     # special cases i = 1
     z1 = view(zs, 1, :)
     dzi .= @views (zs[2, :] .- zs[N, :]) ./ 2
-    I += dot(θ(z1, t, p), dzi)
+    θ(θi, t, z1, p)
+    I += dot(θi, dzi)
 
     # special cases i = N
     zN = view(zs, N, :)
     dzi .= @views (zs[1, :] .- zs[N-1, :]) ./ 2
-    I += dot(θ(zN, t, p), dzi)
+    θ(θi, t, zN, p)
+    I += dot(θi, dzi)
 
     return I
 end

--- a/src/FirstFourierPlans.jl
+++ b/src/FirstFourierPlans.jl
@@ -40,7 +40,7 @@ function compute!(
 
     θ = getform(pinv)
     for (i, z) in enumerate(eachrow(zs))
-        plan.θs[i, :] .= θ(z, t, p)
+        θ(view(plan.θs, i, :), t, z, p)
     end
 
     I = zero(T)

--- a/src/PoincareInvariants.jl
+++ b/src/PoincareInvariants.jl
@@ -15,7 +15,7 @@ export getdim, getform, getplan
 export FirstFinDiffPlan, FirstFourierPlan
 export SecondChebyshevPlan, SecondFinDiffPlan
 
-export canonical_one_form, CanonicalSymplecticMatrix, canonical_two_form
+export canonical_one_form!, CanonicalSymplecticMatrix
 
 # JuliaGNI ecosystem integration
 
@@ -45,6 +45,14 @@ of the curve or surface parameterisation evaluated on some set of points, e.g. a
 
 `t` is the time at which the invariant is evaluated `p` are any user supplied optional
 arguments. Both `t` and `p` are passed directly to the differential form.
+
+The differential form is an **in-place** function following the convention
+`form(out, t, z, p)`: it writes its value at the phase space point `z` (one point, a length-`D`
+vector) into the preallocated output `out` — a length-`D` vector for a one form `θ`, a `D×D`
+matrix for a two form `ω`. This argument order matches the one- and two-forms exported by
+`GeometricEquations`/`GeometricProblems` (`ϑ(Θ, t, q, params)`, `ω(Ω, t, q, params)`), so a
+problem's own forms can be passed directly. A constant `ω::AbstractMatrix` (e.g. a
+`CanonicalSymplecticMatrix`) is used as-is and is not called.
 
 Plan implementations should define a method `compute!(pinv, t::Real, p)`, which acts on the
 internal points storage `pinv.points`.
@@ -148,8 +156,7 @@ function getform end
 
 include("CanonicalSymplecticForms.jl")
 
-using .CanonicalSymplecticForms: canonical_one_form, CanonicalSymplecticMatrix,
-    canonical_two_form
+using .CanonicalSymplecticForms: canonical_one_form!, CanonicalSymplecticMatrix
 
 
 ## FirstPoincareInvariant ##
@@ -203,20 +210,20 @@ function FirstPoincareInvariant{T, D}(
 end
 
 """
-    FirstPoincareInvariant{T, D, typeof(canonical_one_form)}(N::Integer, P=DEFAULT_FIRST_PLAN)
+    FirstPoincareInvariant{T, D, typeof(canonical_one_form!)}(N::Integer, P=DEFAULT_FIRST_PLAN)
     CanonicalFirstPI{T, D}(N::Integer, P=DEFAULT_FIRST_PLAN)
 
 creates a setup object to compute the first integral invariant using the canonical one form
 in phase space of dimension `D` with numeric type `T`, `N` points and plan type `P`.
 """
-function FirstPoincareInvariant{T, D, typeof(canonical_one_form)}(
+function FirstPoincareInvariant{T, D, typeof(canonical_one_form!)}(
     N::Integer, P=DEFAULT_FIRST_PLAN
 ) where {T, D}
-    FirstPoincareInvariant{T, D}(canonical_one_form, N, P)
+    FirstPoincareInvariant{T, D}(canonical_one_form!, N, P)
 end
 
 const FirstPI = FirstPoincareInvariant
-const CanonicalFirstPI{T, D} = FirstPoincareInvariant{T, D, typeof(canonical_one_form)}
+const CanonicalFirstPI{T, D} = FirstPoincareInvariant{T, D, typeof(canonical_one_form!)}
 
 # Interface
 

--- a/src/SecondChebyshevPlans.jl
+++ b/src/SecondChebyshevPlans.jl
@@ -12,6 +12,8 @@ using ..PoincareInvariants: SecondPoincareInvariant, @argcheck
 
 using LinearAlgebra
 
+using StaticArrays: MMatrix
+
 using ChebyshevTransforms
 
 ## Differentiation ##
@@ -99,13 +101,16 @@ function getintegrand!(
     invpaduatransform!(plan.∂xvals, plan.invpaduaplan, ∂xcoeffs)
     invpaduatransform!(plan.∂yvals, plan.invpaduaplan, ∂ycoeffs)
 
+    ωbuf = MMatrix{D, D, T}(undef)
+
     for i in axes(plan.intvals, 1)
         # This if statement should hopefully get optimised away by the compiler
         if ωT <: AbstractMatrix
             ωi = ω
         else
             pnti = view(points, i, :)
-            ωi = ω(pnti, t, p)
+            ω(ωbuf, t, pnti, p)
+            ωi = ωbuf
         end
 
         ∂xi = view(plan.∂xvals, i, :)

--- a/src/SecondFinDiffPlans.jl
+++ b/src/SecondFinDiffPlans.jl
@@ -7,6 +7,8 @@ using ..PoincareInvariants: @argcheck
 
 using LinearAlgebra: dot
 
+using StaticArrays: MVector, MMatrix
+
 struct SecondFinDiffPlan{T, D} end
 
 function SecondFinDiffPlan{T, D}(ω, ps::NTuple{2, Int}) where {T, D}
@@ -23,8 +25,9 @@ function compute!(
 
     I = zero(T)
 
-    ∂xi = Vector{T}(undef, D)
-    ∂yi = Vector{T}(undef, D)
+    ∂xi = MVector{D, T}(undef)
+    ∂yi = MVector{D, T}(undef)
+    ωbuf = MMatrix{D, D, T}(undef)
 
     colviews = [view(points, :, d) for d in 1:D]
 
@@ -40,7 +43,8 @@ function compute!(
                 ωi = pinv.ω
             else
                 pnti = view(points, i, :)
-                ωi = pinv.ω(pnti, t, p)
+                pinv.ω(ωbuf, t, pnti, p)
+                ωi = ωbuf
             end
 
             w = getsimpweight(T, ix, iy, (nx, ny))

--- a/test/test_CanonicalSymplecticForms.jl
+++ b/test/test_CanonicalSymplecticForms.jl
@@ -1,10 +1,10 @@
-@safetestset "canonical_one_form" begin
-    using PoincareInvariants: canonical_one_form
+@safetestset "canonical_one_form!" begin
+    using PoincareInvariants: canonical_one_form!
     using LinearAlgebra: dot
     using Random: rand
 
-    @test_throws ArgumentError canonical_one_form([1, 2, 3], 0.5, nothing)
-    @test_throws ArgumentError canonical_one_form([0.3], 3.4, nothing)
+    @test_throws ArgumentError canonical_one_form!(zeros(3), 0.5, [1, 2, 3], nothing)
+    @test_throws ArgumentError canonical_one_form!(zeros(1), 3.4, [0.3], nothing)
 
     for mid in [3, 9, 22]
         n = mid * 2
@@ -13,9 +13,10 @@
         p = rand(mid)
         z = [q; p]
 
-        @inferred canonical_one_form(z, 0.1, nothing)
+        θ = zeros(n)
+        @inferred canonical_one_form!(θ, 0.1, z, nothing)
 
-        θ = canonical_one_form(z, 1.3, nothing)
+        canonical_one_form!(θ, 1.3, z, nothing)
 
         @test θ[1:mid] == p
         @test θ[mid+1:end] == zeros(mid)
@@ -27,8 +28,8 @@
     end
 end
 
-@safetestset "canonical_two_form" begin
-    using PoincareInvariants: CanonicalSymplecticMatrix, canonical_two_form
+@safetestset "CanonicalSymplecticMatrix" begin
+    using PoincareInvariants: CanonicalSymplecticMatrix
     using LinearAlgebra: dot
     using Random: rand
 
@@ -87,9 +88,5 @@ end
         @test vCw ≈ dot(v, C * w)
 
         @test_throws ArgumentError CanonicalSymplecticMatrix{T}(n + 1)
-
-        @inferred CanonicalSymplecticMatrix{Float64} canonical_two_form(v, 0.1, nothing)
-
-        @test canonical_two_form(v, 0.1, nothing) == CanonicalSymplecticMatrix(n)
     end
 end

--- a/test/test_FirstFinDiffPlans.jl
+++ b/test/test_FirstFinDiffPlans.jl
@@ -33,7 +33,8 @@ end
     T = Float64
     D = 3
 
-    θ(z, t, p) = SVector{3}(p * z[2], -t * z[1], z[3])
+    # in-place one form following the form(out, t, z, p) convention
+    θ!(out, t, z, p) = (out[1] = p * z[2]; out[2] = -t * z[1]; out[3] = z[3]; nothing)
     f(x) = ((s, c) = sincospi(2x); SVector{3}(2c,  5s, c + s))
 
     T = Float64
@@ -52,9 +53,11 @@ end
         end
 
         fi = fvals[i, :]
-        return Δx * dot(θ(fi, 2, 3), dfi)
+        θi = zeros(D)
+        θ!(θi, 2, fi, 3)
+        return Δx * dot(θi, dfi)
     end
 
-    pinv = FirstPoincareInvariant{T, D}(θ, N, FirstFinDiffPlan{T, D}())
+    pinv = FirstPoincareInvariant{T, D}(θ!, N, FirstFinDiffPlan{T, D}())
     @test compute!(pinv, fvals, 2, 3) ≈ testI atol=500eps()
 end

--- a/test/test_FirstFourierPlans.jl
+++ b/test/test_FirstFourierPlans.jl
@@ -31,8 +31,8 @@ end
     T = Float64
     D = 2
 
-    # rotating vector field
-    θ(z, p, t) = [-z[2], z[1]]
+    # rotating vector field, in-place following the form(out, t, z, p) convention
+    θ!(out, t, z, p) = (out[1] = -z[2]; out[2] = z[1]; nothing)
 
     # circular path with radius R
     # ḟ = 2π .* R .* (-sinpi(2ϕ), cospi(2ϕ))
@@ -43,8 +43,8 @@ end
     I = 2π * R^2
 
     N = 10
-    plan = FirstFourierPlan{T, D}(θ, N)
-    pinv = FirstPoincareInvariant{T, D}(θ, N, plan)
+    plan = FirstFourierPlan{T, D}(θ!, N)
+    pinv = FirstPoincareInvariant{T, D}(θ!, N, plan)
     pnts = getpoints(f, Float64, N, FirstFourierPlan)
     @test I ≈ compute!(pinv, pnts, 0.0, nothing) atol=10eps()
 end

--- a/test/test_Integration.jl
+++ b/test/test_Integration.jl
@@ -7,7 +7,7 @@ using Test
 
 const HarmonicOscillator     = GeometricProblems.HarmonicOscillator
 const Pendulum               = GeometricProblems.Pendulum
-const MasslessChargedParticle = GeometricProblems.MasslessChargedParticle
+const MasslessChargedParticleSingular = GeometricProblems.MasslessChargedParticleSingular
 const LotkaVolterra2dSingular = GeometricProblems.LotkaVolterra2dSingular
 
 # maximum deviation of a time series of invariant values from its initial value
@@ -59,25 +59,24 @@ end
 end
 
 ## Noncanonical systems ########################################################
-# MasslessChargedParticle and LotkaVolterra2dSingular carry a state-dependent (non-
-# canonical) symplectic structure. We integrate their degenerate IODE/LODE form
+# MasslessChargedParticleSingular and LotkaVolterra2dSingular carry a state-dependent
+# (noncanonical) symplectic structure. We integrate their degenerate IODE/LODE form
 # with a Degenerate Variational Runge-Kutta method (DVRK), which is designed for
 # noncanonical symplectic systems and preserves the noncanonical one-form ϑ and
 # two-form ω = dϑ (unlike the DVI methods, which preserve a discrete canonical
-# structure). The invariant forms are reused directly from the GeometricProblems
-# modules.
+# structure). Both use a "singular" gauge whose one-form is exactly the symplectic
+# potential DVRK expects, so the invariants are preserved to machine accuracy. The
+# invariant forms are reused directly from the GeometricProblems modules.
 
-@testset "MasslessChargedParticle (noncanonical)" begin
-    par = MasslessChargedParticle.default_parameters()
-    prob = MasslessChargedParticle.iodeproblem([1.0, 1.0]; timespan = (0.0, 1.0), timestep = 0.05)
+@testset "MasslessChargedParticleSingular (noncanonical)" begin
+    prob = MasslessChargedParticleSingular.lodeproblem([1.0, 1.0]; timespan = (0.0, 1.0), timestep = 0.05)
+    par  = parameters(prob)
 
-    # one-form ϑ = A(x) (magnetic vector potential); two-form ω = [0 B; -B 0]
-    oneform(z, t, p) = SVector{2}(MasslessChargedParticle.ϑ(t, z, p))
-    function twoform(z, t, p)
-        b = MasslessChargedParticle.B(z, p)
-        @SMatrix [0.0  b;
-                  -b   0.0]
-    end
+    # one-form ϑ = A(x) and two-form ω = dϑ, pulled directly from the problem's function
+    # tuple (in-place, parameter-carrying) — identical setup to LotkaVolterra2dSingular below
+    fs = functions(prob)
+    oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
+    twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 
     q₀ = SVector(1.0, 1.0)
     ρ = 0.2
@@ -86,27 +85,27 @@ end
     ens1 = PIEnsembleProblem(prob, pi1, ϕ -> q₀ .+ ρ .* (cospi(2ϕ), sinpi(2ϕ)))
     sol1 = integrate(ens1, DVRK(Gauss(2)))
     Is1 = compute!(pi1, sol1, par)
-    @test maxdev(Is1) < 1e-3
+    @test maxdev(Is1) < 1e-13
 
     pi2 = SecondPI{Float64, 2}(twoform, 2_000)
     ens2 = PIEnsembleProblem(prob, pi2, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1))
     sol2 = integrate(ens2, DVRK(Gauss(2)))
     Is2 = compute!(pi2, sol2, par)
-    @test maxdev(Is2) < 1e-3
+    @test maxdev(Is2) < 1e-13
 end
 
 @testset "LotkaVolterra2dSingular (noncanonical)" begin
     # the "singular" Lagrangian carries the form of the symplectic potential that DVRK
     # expects, so the noncanonical invariants are preserved to machine accuracy
     prob = LotkaVolterra2dSingular.lodeproblem([2.0, 1.0]; timespan = (0.0, 1.0), timestep = 0.05)
+    par  = parameters(prob)
 
-    # one-form ϑ and two-form ω = dϑ, taken from the problem module
-    oneform(z, t, p) = SVector{2}(LotkaVolterra2dSingular.ϑ(t, z))
-    function twoform(z, t, p)
-        Ω = zeros(eltype(z), 2, 2)
-        LotkaVolterra2dSingular.ω(Ω, t, z)
-        SMatrix{2, 2}(Ω)
-    end
+    # one-form ϑ and two-form ω = dϑ, pulled directly from the problem's function tuple so
+    # the invariant forms are exactly the (in-place, parameter-carrying) functions the
+    # problem was integrated with
+    fs = functions(prob)
+    oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
+    twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 
     q₀ = SVector(2.0, 1.0)
     ρ = 0.2
@@ -114,12 +113,12 @@ end
     pi1 = FirstPI{Float64, 2}(oneform, 500)
     ens1 = PIEnsembleProblem(prob, pi1, ϕ -> q₀ .+ ρ .* (cospi(2ϕ), sinpi(2ϕ)))
     sol1 = integrate(ens1, DVRK(Gauss(2)))
-    Is1 = compute!(pi1, sol1)
+    Is1 = compute!(pi1, sol1, par)
     @test maxdev(Is1) < 1e-11
 
     pi2 = SecondPI{Float64, 2}(twoform, 2_000)
     ens2 = PIEnsembleProblem(prob, pi2, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1))
     sol2 = integrate(ens2, DVRK(Gauss(2)))
-    Is2 = compute!(pi2, sol2)
+    Is2 = compute!(pi2, sol2, par)
     @test maxdev(Is2) < 1e-11
 end

--- a/test/test_Integration.jl
+++ b/test/test_Integration.jl
@@ -72,22 +72,21 @@ end
     prob = MasslessChargedParticleSingular.lodeproblem([1.0, 1.0]; timespan = (0.0, 1.0), timestep = 0.05)
     par  = parameters(prob)
 
-    # one-form ϑ = A(x) and two-form ω = dϑ, pulled directly from the problem's function
-    # tuple (in-place, parameter-carrying) — identical setup to LotkaVolterra2dSingular below
+    # the in-place one-form ϑ and two-form ω = dϑ of the problem match the invariant form
+    # convention `form(out, t, z, p)` exactly, so we pass them straight to FirstPI / SecondPI
+    # with no wrapper — identical setup to LotkaVolterra2dSingular below
     fs = functions(prob)
-    oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
-    twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 
     q₀ = SVector(1.0, 1.0)
     ρ = 0.2
 
-    pi1 = FirstPI{Float64, 2}(oneform, 500)
+    pi1 = FirstPI{Float64, 2}(fs.ϑ, 500)
     ens1 = PIEnsembleProblem(prob, pi1, ϕ -> q₀ .+ ρ .* (cospi(2ϕ), sinpi(2ϕ)))
     sol1 = integrate(ens1, DVRK(Gauss(2)))
     Is1 = compute!(pi1, sol1, par)
     @test maxdev(Is1) < 1e-13
 
-    pi2 = SecondPI{Float64, 2}(twoform, 2_000)
+    pi2 = SecondPI{Float64, 2}(fs.ω, 2_000)
     ens2 = PIEnsembleProblem(prob, pi2, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1))
     sol2 = integrate(ens2, DVRK(Gauss(2)))
     Is2 = compute!(pi2, sol2, par)
@@ -100,23 +99,20 @@ end
     prob = LotkaVolterra2dSingular.lodeproblem([2.0, 1.0]; timespan = (0.0, 1.0), timestep = 0.05)
     par  = parameters(prob)
 
-    # one-form ϑ and two-form ω = dϑ, pulled directly from the problem's function tuple so
-    # the invariant forms are exactly the (in-place, parameter-carrying) functions the
-    # problem was integrated with
+    # the problem's in-place one-form ϑ and two-form ω = dϑ follow the `form(out, t, z, p)`
+    # convention, so they are passed directly as the invariant forms
     fs = functions(prob)
-    oneform(z, t, p) = (Θ = zeros(eltype(z), 2);    fs.ϑ(Θ, t, z, p); SVector{2}(Θ))
-    twoform(z, t, p) = (Ω = zeros(eltype(z), 2, 2); fs.ω(Ω, t, z, p); SMatrix{2, 2}(Ω))
 
     q₀ = SVector(2.0, 1.0)
     ρ = 0.2
 
-    pi1 = FirstPI{Float64, 2}(oneform, 500)
+    pi1 = FirstPI{Float64, 2}(fs.ϑ, 500)
     ens1 = PIEnsembleProblem(prob, pi1, ϕ -> q₀ .+ ρ .* (cospi(2ϕ), sinpi(2ϕ)))
     sol1 = integrate(ens1, DVRK(Gauss(2)))
     Is1 = compute!(pi1, sol1, par)
     @test maxdev(Is1) < 1e-11
 
-    pi2 = SecondPI{Float64, 2}(twoform, 2_000)
+    pi2 = SecondPI{Float64, 2}(fs.ω, 2_000)
     ens2 = PIEnsembleProblem(prob, pi2, (x, y) -> q₀ .+ ρ .* (2x - 1, 2y - 1))
     sol2 = integrate(ens2, DVRK(Gauss(2)))
     Is2 = compute!(pi2, sol2, par)

--- a/test/test_PoincareInvariants.jl
+++ b/test/test_PoincareInvariants.jl
@@ -2,7 +2,7 @@
     @safetestset "FirstPoincareInvariant" begin
         using PoincareInvariants
 
-        D = 6; N = 123; θ = canonical_one_form; P = FirstFinDiffPlan
+        D = 6; N = 123; θ = canonical_one_form!; P = FirstFinDiffPlan
         pinv = FirstPoincareInvariant{Float64, D}(θ, N, P)
 
         @test getdim(pinv) == D
@@ -23,7 +23,7 @@
     @safetestset "SecondPoincareInvariant" begin
         using PoincareInvariants
 
-        D = 4; N = 321; ω = canonical_two_form; P = SecondFinDiffPlan
+        D = 4; N = 321; ω = CanonicalSymplecticMatrix{Float64}(D); P = SecondFinDiffPlan
         pinv = SecondPoincareInvariant{Float64, D}(ω, N, P)
 
         @test getdim(pinv) == D
@@ -62,15 +62,15 @@ end
         ]
 
         first_pinvs = [
-            FirstPoincareInvariant{Ts[1], D}(canonical_one_form, Ns[1]),
-            FirstPoincareInvariant{Ts[2], D}(canonical_one_form, Ns[2], FirstFinDiffPlan),
-            FirstPoincareInvariant{Ts[3], D}(canonical_one_form, Ns[3], FirstFinDiffPlan),
-            FirstPoincareInvariant{Ts[4], D}(canonical_one_form, Ns[4], FirstFourierPlan),
-            FirstPoincareInvariant{Ts[5], D}(canonical_one_form, Ns[5], FirstFourierPlan),
+            FirstPoincareInvariant{Ts[1], D}(canonical_one_form!, Ns[1]),
+            FirstPoincareInvariant{Ts[2], D}(canonical_one_form!, Ns[2], FirstFinDiffPlan),
+            FirstPoincareInvariant{Ts[3], D}(canonical_one_form!, Ns[3], FirstFinDiffPlan),
+            FirstPoincareInvariant{Ts[4], D}(canonical_one_form!, Ns[4], FirstFourierPlan),
+            FirstPoincareInvariant{Ts[5], D}(canonical_one_form!, Ns[5], FirstFourierPlan),
 
-            FirstPI{Ts[6], D}(canonical_one_form, Ns[6]),
-            FirstPI{Ts[7], D}(canonical_one_form, Ns[7], FirstFinDiffPlan),
-            FirstPI{Ts[8], D}(canonical_one_form, Ns[8], FirstFourierPlan),
+            FirstPI{Ts[6], D}(canonical_one_form!, Ns[6]),
+            FirstPI{Ts[7], D}(canonical_one_form!, Ns[7], FirstFinDiffPlan),
+            FirstPI{Ts[8], D}(canonical_one_form!, Ns[8], FirstFourierPlan),
 
             CanonicalFirstPI{Ts[9], D}(Ns[9]),
             CanonicalFirstPI{Ts[10], D}(Ns[10], FirstFinDiffPlan),
@@ -117,15 +117,15 @@ end
         ]
 
         second_pinvs = [
-            SecondPoincareInvariant{Ts[1], D}(canonical_two_form, ps[1]),
-            SecondPoincareInvariant{Ts[2], D}(canonical_two_form, ps[2], SecondChebyshevPlan),
-            SecondPoincareInvariant{Ts[3], D}(canonical_two_form, ps[3], SecondChebyshevPlan),
-            SecondPoincareInvariant{Ts[4], D}(canonical_two_form, ps[4], SecondFinDiffPlan),
-            SecondPoincareInvariant{Ts[5], D}(canonical_two_form, ps[5], SecondFinDiffPlan),
+            SecondPoincareInvariant{Ts[1], D}(CanonicalSymplecticMatrix{Ts[1]}(D), ps[1]),
+            SecondPoincareInvariant{Ts[2], D}(CanonicalSymplecticMatrix{Ts[2]}(D), ps[2], SecondChebyshevPlan),
+            SecondPoincareInvariant{Ts[3], D}(CanonicalSymplecticMatrix{Ts[3]}(D), ps[3], SecondChebyshevPlan),
+            SecondPoincareInvariant{Ts[4], D}(CanonicalSymplecticMatrix{Ts[4]}(D), ps[4], SecondFinDiffPlan),
+            SecondPoincareInvariant{Ts[5], D}(CanonicalSymplecticMatrix{Ts[5]}(D), ps[5], SecondFinDiffPlan),
 
-            SecondPI{Ts[6], D}(canonical_two_form, ps[6]),
-            SecondPI{Ts[7], D}(canonical_two_form, ps[7], SecondChebyshevPlan),
-            SecondPI{Ts[8], D}(canonical_two_form, ps[8], SecondFinDiffPlan),
+            SecondPI{Ts[6], D}(CanonicalSymplecticMatrix{Ts[6]}(D), ps[6]),
+            SecondPI{Ts[7], D}(CanonicalSymplecticMatrix{Ts[7]}(D), ps[7], SecondChebyshevPlan),
+            SecondPI{Ts[8], D}(CanonicalSymplecticMatrix{Ts[8]}(D), ps[8], SecondFinDiffPlan),
 
             SecondPI{Ts[9], D}(CanonicalSymplecticMatrix{Float64}(D), ps[9]),
             SecondPI{Ts[10], D}(CanonicalSymplecticMatrix{Double64}(D), ps[10], SecondChebyshevPlan),
@@ -162,22 +162,26 @@ end
         using PoincareInvariants
 
         D = 6
-        θ(z, t, p) = [-z[4], -z[5], -p * z[6], t * z[1], p * z[2], z[3]]
+        function θ!(out, t, z, p)
+            out[1] = -z[4]; out[2] = -z[5]; out[3] = -p * z[6]
+            out[4] = t * z[1]; out[5] = p * z[2]; out[6] = z[3]
+            nothing
+        end
 
         function f(ϕ)
             y, x = sincospi(2ϕ)
             return 0.5 * x, x, 3 * x, 0.1 * y, 0.85 * y, 2 * y
         end
 
-        Idefault = let pinv = FirstPI{Float64, D}(θ, 1_000)
+        Idefault = let pinv = FirstPI{Float64, D}(θ!, 1_000)
             compute!(pinv, getpoints(f, pinv), 0.3, 0.1)
         end
 
-        Idiff = let pinv = FirstPI{Float64, D}(θ, 1_000, FirstFinDiffPlan)
+        Idiff = let pinv = FirstPI{Float64, D}(θ!, 1_000, FirstFinDiffPlan)
             compute!(pinv, getpoints(f, pinv), 0.3, 0.1)
         end
 
-        Ifreq = let pinv = FirstPI{Float64, D}(θ, 1_000, FirstFourierPlan)
+        Ifreq = let pinv = FirstPI{Float64, D}(θ!, 1_000, FirstFourierPlan)
             compute!(pinv, getpoints(f, pinv), 0.3, 0.1)
         end
 
@@ -189,14 +193,16 @@ end
         using PoincareInvariants
 
         D = 6
-        ω(z, t, p) = [
-                0     0     0  z[1]  z[2]  z[3]
-                0     0     0  z[4]  z[5]  z[6]
-                0     0     0     t     p     1
-            -z[1] -z[4]    -t     0     0     0
-            -z[2] -z[5]    -p     0     0     0
-            -z[3] -z[6]    -1     0     0     0
-        ]
+        function ω!(out, t, z, p)
+            out .= 0
+            out[1, 4] =  z[1]; out[1, 5] =  z[2]; out[1, 6] =  z[3]
+            out[2, 4] =  z[4]; out[2, 5] =  z[5]; out[2, 6] =  z[6]
+            out[3, 4] =     t; out[3, 5] =     p; out[3, 6] =     1
+            out[4, 1] = -z[1]; out[4, 2] = -z[4]; out[4, 3] =    -t
+            out[5, 1] = -z[2]; out[5, 2] = -z[5]; out[5, 3] =    -p
+            out[6, 1] = -z[3]; out[6, 2] = -z[6]; out[6, 3] =    -1
+            nothing
+        end
 
         f(x, y) = (
             exp(x) * y,
@@ -207,15 +213,15 @@ end
             x + y
         )
 
-        Idefault = let pinv = SecondPI{Float64, D}(ω, 1_000)
+        Idefault = let pinv = SecondPI{Float64, D}(ω!, 1_000)
             compute!(pinv, getpoints(f, pinv), 5, 11)
         end
 
-        Icheb = let pinv = SecondPI{Float64, D}(ω, 1_000, SecondChebyshevPlan)
+        Icheb = let pinv = SecondPI{Float64, D}(ω!, 1_000, SecondChebyshevPlan)
             compute!(pinv, getpoints(f, pinv), 5, 11)
         end
 
-        Ifindiff = let pinv = SecondPI{Float64, D}(ω, (31, 33), SecondFinDiffPlan)
+        Ifindiff = let pinv = SecondPI{Float64, D}(ω!, (31, 33), SecondFinDiffPlan)
             compute!(pinv, getpoints(f, pinv), 5, 11)
         end
 
@@ -232,11 +238,20 @@ end
     Nsteps = 13
     times = [2.0 + n * 0.15 for n in 0:Nsteps-1]
 
-    f1(z, t, p) = canonical_one_form(z, t, p) .* t
-    pi1 = FirstPI{Float64, D}(f1, N)
+    # in-place forms scaled by the time t, following the form(out, t, z, p) convention
+    f1!(out, t, z, p) = (canonical_one_form!(out, t, z, p); out .*= t; nothing)
+    pi1 = FirstPI{Float64, D}(f1!, N)
 
-    f2(z, t, p) = canonical_two_form(z, t, p) .* t
-    pi2 = SecondPI{Float64, D}(f2, N)
+    function f2!(out, t, z, p)
+        out .= 0
+        mid = length(z) ÷ 2
+        for i in 1:mid
+            out[i, mid + i] = -t
+            out[mid + i, i] =  t
+        end
+        nothing
+    end
+    pi2 = SecondPI{Float64, D}(f2!, N)
 
     p1(θ) = (cospi(2θ), cospi(2θ), sinpi(2θ), sinpi(2θ))
     p2(x, y) = (x, x, y, y)

--- a/test/test_SecondChebyshevPlans.jl
+++ b/test/test_SecondChebyshevPlans.jl
@@ -91,13 +91,13 @@ end
         iplan = InvPaduaTransformPlan{Float64}(degree)
         invpaduatransform!(phasepoints, iplan, phasecoeffs)
 
-        ω(v, t, p) = [0 -1; 1  0]
+        ω!(out, t, z, p) = (out[1, 1] = 0; out[1, 2] = -1; out[2, 1] = 1; out[2, 2] = 0; nothing)
 
         plan = CallIntPlan{Float64, D}(degree)
 
         intcoeffs = zeros(degree+1, degree+1)
 
-        getintegrand!(intcoeffs, plan, ω, phasepoints, 0, nothing, ∂xcoeffs, ∂ycoeffs)
+        getintegrand!(intcoeffs, plan, ω!, phasepoints, 0, nothing, ∂xcoeffs, ∂ycoeffs)
 
         @test intcoeffs ≈ [-72   -82  -30;
                            -82  -432    0;
@@ -124,7 +124,7 @@ end
         iplan = InvPaduaTransformPlan{Float64}(degree)
         invpaduatransform!(phasepoints, iplan, phasecoeffs)
 
-        ω = canonical_two_form
+        ω = CanonicalSymplecticMatrix{Float64}(D)
 
         plan = CallIntPlan{Float64, D}(degree)
 
@@ -146,7 +146,7 @@ end
 
     D = 12
     N = 200
-    ω = canonical_two_form
+    ω = CanonicalSymplecticMatrix{Float64}(D)
     pointnum = nextpaduanum(N)
     degree = getdegree(pointnum)
     plan = SecondChebyshevPlan{Float64, D}(ω, pointnum)

--- a/test/test_SecondFinDiffPlans.jl
+++ b/test/test_SecondFinDiffPlans.jl
@@ -184,16 +184,26 @@ end
         15 + 17*x + 36*y,
         21 + 23*x + 48*y]
 
-    ω(z, ::Any, ::Any) = [0 0 z[1] z[2]; 0 0 z[3] z[4]; -z[1] -z[3] 0 0; -z[2] -z[4] 0 0]
+    # in-place two form following the form(out, t, z, p) convention
+    function ω!(out, t, z, p)
+        out .= 0
+        out[1, 3] =  z[1]; out[1, 4] =  z[2]
+        out[2, 3] =  z[3]; out[2, 4] =  z[4]
+        out[3, 1] = -z[1]; out[3, 2] = -z[3]
+        out[4, 1] = -z[2]; out[4, 2] = -z[4]
+        nothing
+    end
     nx, ny = 11, 17
     integrand = getpoints(Float64, (nx, ny), SecondFinDiffPlan) do x, y
-        dot(fy(x, y), ω(f(x, y), 0, nothing), fx(x, y))
+        Ω = zeros(4, 4)
+        ω!(Ω, 0, f(x, y), nothing)
+        dot(fy(x, y), Ω, fx(x, y))
     end
 
     ws = [getsimpweight(Float64, ix, iy, (nx, ny)) for iy in 1:ny, ix in 1:nx] |> vec
     testI = dot(ws, integrand)
 
-    pinv = SecondPoincareInvariant{Float64, 4}(ω, (nx, ny), SecondFinDiffPlan)
+    pinv = SecondPoincareInvariant{Float64, 4}(ω!, (nx, ny), SecondFinDiffPlan)
 
     @test pinv.plan isa SecondFinDiffPlan
 


### PR DESCRIPTION
Two related changes to how noncanonical Poincaré invariants are set up and computed.

## 1. Use the singular problems and take invariant forms from the `LODEProblem`

- Switch the docs and tests to the "singular"-gauge noncanonical problems
  (`MasslessChargedParticleSingular`, `LotkaVolterra2dSingular`) and integrate them via their
  `lodeproblem`.
- Take the one-form `ϑ` and two-form `ω = dϑ` straight from the problem via `functions(prob)`
  (with `parameters(prob)` forwarded through `compute!` / `plot_invariant`), instead of
  re-referencing module-level forms.
- Requires **GeometricProblems ≥ 0.7.2**, which adds `MasslessChargedParticleSingular.lodeproblem`
  and fixes the `LODEProblem` `ω`/lagrangian argument order so `functions(prob).ω` returns the
  two-form.

## 2. Make the differential-form interface in-place

- Change the form interface from value-returning closures `form(z, t, p)` (returning an
  `SVector`/`SMatrix` per sample point) to **in-place** functions `form(out, t, z, p)` that write
  into a preallocated output.
- The argument order matches the forms exported by GeometricEquations/GeometricProblems
  (`ϑ(Θ, t, q, params)`, `ω(Ω, t, q, params)`), so a problem's own forms can be passed
  **directly** — no wrapper closures.
- Each plan fills a single reused `StaticArrays` buffer (`MVector`/`MMatrix`), so evaluating the
  form no longer allocates per sample point (`@allocated compute!` is now flat in the sample
  count). The constant `CanonicalSymplecticMatrix` fast path is unchanged.
- Adds in-place `canonical_one_form!`; drops the value-returning `canonical_one_form` /
  `canonical_two_form` and the lazy `CanonicalSymplecticVector`.

## Docs

- The Lotka-Volterra and massless-charged-particle example pages pass `fs.ϑ`/`fs.ω` directly.
- `implementation.md` documents the in-place convention.
- The **tutorial** is rewritten: explains the in-place interface, adds a worked noncanonical
  example, and adds "choosing an invariant/plan" and "common pitfalls" sections (worked examples
  are executable `@example` blocks).

## Verification

- Full test suite passes; noncanonical integration tests conserve both invariants to machine
  precision with the problem forms passed directly.
- Allocation spot-checks confirm no per-sample-point allocation.
- Full docs build succeeds (all example/tutorial `@example` blocks execute, `@docs` references
  resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)